### PR TITLE
`StblBox` の情報へのアクセスを簡単かつ安全にするための `SampleTableAccessor` 構造体を追加する (+ α)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [ADD] `StblBox` の情報へのアクセスを簡単かつ安全にするための `SampleTableAccessor` 構造体を追加する
+  - @sile
+- [ADD] `SttsBox::from_sample_deltas()` 関数を追加する
+  - @sile
 - [ADD] `Utf8String::into_null_terminated_bytes()` メソッドを追加する
   - @sile
 - [CHANGE] 仕様上 0 を取らないフィールドの型は `NonZeroXXX` にする

--- a/src/aux.rs
+++ b/src/aux.rs
@@ -1,0 +1,105 @@
+//! MP4 の仕様とは直接は関係がない、実装上便利な補助的なコンポーネントを集めたモジュール
+
+use std::num::NonZeroU32;
+
+use crate::{
+    boxes::{StblBox, StszBox},
+    Either,
+};
+
+/// [`StblBox`] をラップして、その中の情報を簡単かつ効率的に取り出せるようにするための構造体
+#[derive(Debug)]
+pub struct SampleTableAccessor<'a> {
+    stbl_box: &'a StblBox,
+    sample_count: u32,
+    stts_table: Vec<(u32, u32)>, // (累計サンプル数、尺）
+}
+
+impl<'a> SampleTableAccessor<'a> {
+    /// 引数で渡された [`StblBox`] 用の [`SampleTableAccessor`] インスタンスを生成する
+    pub fn new(stbl_box: &'a StblBox) -> Self {
+        let mut stts_table = Vec::new();
+        let mut sample_count = 0;
+        for entry in &stbl_box.stts_box.entries {
+            stts_table.push((sample_count, entry.sample_delta));
+            sample_count += entry.sample_count;
+        }
+
+        Self {
+            stbl_box,
+            sample_count,
+            stts_table,
+        }
+    }
+
+    /// トラック内のサンプルの数を取得する
+    pub fn sample_count(&self) -> u32 {
+        self.sample_count
+    }
+
+    /// トラック内のチャンクの数を取得する
+    pub fn chunk_count(&self) -> u32 {
+        match &self.stbl_box.stco_or_co64_box {
+            Either::A(b) => b.chunk_offsets.len() as u32,
+            Either::B(b) => b.chunk_offsets.len() as u32,
+        }
+    }
+
+    /// 指定されたサンプルの尺を取得する
+    ///
+    /// 存在しないサンプルが指定された場合には [`None`] が返される
+    pub fn sample_duration(&self, sample_index: NonZeroU32) -> Option<u32> {
+        if self.sample_count < sample_index.get() {
+            return None;
+        }
+
+        let i = self
+            .stts_table
+            .binary_search_by_key(&(sample_index.get() - 1), |x| x.0)
+            .map(|i| i)
+            .unwrap_or_else(|i| i);
+        self.stts_table.get(i).map(|x| x.1)
+    }
+
+    /// 指定されたサンプルのデータサイズ（バイト数）を取得する
+    ///
+    /// 存在しないサンプルが指定された場合には [`None`] が返される
+    pub fn sample_size(&self, sample_index: NonZeroU32) -> Option<u32> {
+        if self.sample_count < sample_index.get() {
+            return None;
+        }
+
+        let i = sample_index.get() as usize - 1;
+        match &self.stbl_box.stsz_box {
+            StszBox::Fixed { sample_size, .. } => Some(sample_size.get()),
+            StszBox::Variable { entry_sizes } => entry_sizes.get(i).copied(),
+        }
+    }
+
+    /// 指定されたサンプルが同期サンプルかどうかを判定する
+    ///
+    /// 存在しないサンプルが指定された場合には [`None`] が返される
+    pub fn is_sync_sample(&self, sample_index: NonZeroU32) -> Option<bool> {
+        if self.sample_count < sample_index.get() {
+            return None;
+        }
+
+        let Some(stss_box) = &self.stbl_box.stss_box else {
+            // stss ボックスが存在しない場合は全てが同期サンプル扱い
+            return Some(true);
+        };
+
+        Some(stss_box.sample_numbers.binary_search(&sample_index).is_ok())
+    }
+
+    /// 指定されたチャンクのファイル内でのバイト位置を返す
+    ///
+    /// 存在しないチャンクが指定された場合には [`None`] が返される
+    pub fn chunk_offset(&self, chunk_index: NonZeroU32) -> Option<u64> {
+        let i = chunk_index.get() as usize - 1;
+        match &self.stbl_box.stco_or_co64_box {
+            Either::A(b) => b.chunk_offsets.get(i).copied().map(|v| v as u64),
+            Either::B(b) => b.chunk_offsets.get(i).copied(),
+        }
+    }
+}

--- a/src/aux.rs
+++ b/src/aux.rs
@@ -48,65 +48,40 @@ impl<'a> SampleTableAccessor<'a> {
     ///
     /// 存在しないサンプルが指定された場合には [`None`] が返される
     pub fn get_sample(&self, sample_index: NonZeroU32) -> Option<SampleAccessor> {
-        (sample_index.get() <= self.sample_count).then(|| SampleAccessor {
+        (sample_index.get() <= self.sample_count).then_some(SampleAccessor {
             sample_table: self,
             sample_index,
         })
     }
 
-    /// 指定されたチャンクのファイル内でのバイト位置を返す
+    /// 指定されたチャンクの情報を返す
     ///
     /// 存在しないチャンクが指定された場合には [`None`] が返される
-    pub fn get_chunk_offset(&self, chunk_index: NonZeroU32) -> Option<u64> {
-        let i = chunk_index.get() as usize - 1;
-        match &self.stbl_box.stco_or_co64_box {
-            Either::A(b) => b.chunk_offsets.get(i).copied().map(|v| v as u64),
-            Either::B(b) => b.chunk_offsets.get(i).copied(),
-        }
+    pub fn get_chunk(&self, chunk_index: NonZeroU32) -> Option<ChunkAccessor> {
+        (chunk_index.get() <= self.chunk_count()).then_some(ChunkAccessor {
+            sample_table: self,
+            chunk_index,
+        })
     }
 
-    /// 指定されたチャンク内のサンプル数を返す
-    ///
-    /// 存在しないチャンクが指定された場合には [`None`] が返される
-    pub fn get_chunk_sample_count(&self, chunk_index: NonZeroU32) -> Option<u32> {
-        if chunk_index.get() > self.chunk_count() {
-            return None;
-        }
-        if self
-            .stbl_box
-            .stsc_box
-            .entries
-            .get(0)
-            .map_or(true, |x| chunk_index < x.first_chunk)
-        {
-            return None;
-        }
-
-        let i = self
-            .stbl_box
-            .stsc_box
-            .entries
-            .binary_search_by_key(&chunk_index, |x| x.first_chunk)
-            .unwrap_or_else(|i| i.checked_sub(1).expect("unreachable"));
-        self.stbl_box
-            .stsc_box
-            .entries
-            .get(i)
-            .map(|x| x.sample_per_chunk)
+    /// トラック内のサンプル群の情報を走査するイテレーターを返す
+    pub fn samples(&self) -> impl '_ + Iterator<Item = SampleAccessor> {
+        (0..self.sample_count()).map(|i| SampleAccessor {
+            sample_table: self,
+            sample_index: NonZeroU32::MIN.saturating_add(i),
+        })
     }
 
-    /// 指定されたサンプルディスクリプション（サンプルエントリー）を返す
-    ///
-    /// 存在しないサンプルディスクリプションが指定された場合には [`None`] が返される
-    pub fn get_sample_entry(&self, sample_description_index: NonZeroU32) -> Option<&SampleEntry> {
-        self.stbl_box
-            .stsd_box
-            .entries
-            .get(sample_description_index.get() as usize - 1)
+    /// トラック内のチャンク群の情報を走査するイテレーターを返す
+    pub fn chunks(&self) -> impl '_ + Iterator<Item = ChunkAccessor> {
+        (0..self.chunk_count()).map(|i| ChunkAccessor {
+            sample_table: self,
+            chunk_index: NonZeroU32::MIN.saturating_add(i),
+        })
     }
 }
 
-/// TODO: doc
+/// [`StblBox`] 内の個々のサンプルの情報を取得するための構造体
 #[derive(Debug)]
 pub struct SampleAccessor<'a> {
     sample_table: &'a SampleTableAccessor<'a>,
@@ -149,6 +124,65 @@ impl<'a> SampleAccessor<'a> {
     }
 
     // TODO: chunk() -> ChunkAccessor
+}
+
+/// [`StblBox`] 内の個々のチャンクの情報を取得するための構造体
+#[derive(Debug)]
+pub struct ChunkAccessor<'a> {
+    sample_table: &'a SampleTableAccessor<'a>,
+    chunk_index: NonZeroU32,
+}
+
+impl<'a> ChunkAccessor<'a> {
+    /// チャンクのファイル内でのバイト位置を返す
+    pub fn offset(&self) -> u64 {
+        let i = self.chunk_index.get() as usize - 1;
+        match &self.sample_table.stbl_box.stco_or_co64_box {
+            Either::A(b) => b.chunk_offsets[i] as u64,
+            Either::B(b) => b.chunk_offsets[i],
+        }
+    }
+
+    // /// 指定されたチャンク内のサンプル数を返す
+    // ///
+    // /// 存在しないチャンクが指定された場合には [`None`] が返される
+    // pub fn get_chunk_sample_count(&self, chunk_index: NonZeroU32) -> Option<u32> {
+    //     if chunk_index.get() > self.chunk_count() {
+    //         return None;
+    //     }
+    //     if self
+    //         .stbl_box
+    //         .stsc_box
+    //         .entries
+    //         .get(0)
+    //         .map_or(true, |x| chunk_index < x.first_chunk)
+    //     {
+    //         return None;
+    //     }
+
+    //     let i = self
+    //         .stbl_box
+    //         .stsc_box
+    //         .entries
+    //         .binary_search_by_key(&chunk_index, |x| x.first_chunk)
+    //         .unwrap_or_else(|i| i.checked_sub(1).expect("unreachable"));
+    //     self.stbl_box
+    //         .stsc_box
+    //         .entries
+    //         .get(i)
+    //         .map(|x| x.sample_per_chunk)
+    // }
+
+    /// チャンクが参照するサンプルエントリー返す
+    ///
+    /// [`StblBox`] の不整合で、参照先のサンプルエントリーが存在しない場合には [`None`] が返される
+    pub fn sample_entry(&self) -> Option<&SampleEntry> {
+        // self.stbl_box
+        //     .stsd_box
+        //     .entries
+        //     .get(sample_description_index.get() as usize - 1)
+        todo!()
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! MP4 のボックスのエンコードおよびデコードを行うためのライブラリ
 #![warn(missing_docs)]
+pub mod aux;
 mod basic_types;
 pub mod boxes;
 mod io;


### PR DESCRIPTION
Copilot Summary
-----------------

This pull request introduces several new features and modifications to improve the functionality and safety of the codebase. The most significant changes include the addition of a `SampleTableAccessor` struct for easier and safer access to `StblBox` information, a new function `SttsBox::from_sample_deltas()`, and the addition of a new module `aux`.

### New Features:

* Added `SampleTableAccessor` struct to simplify and secure access to `StblBox` information (`CHANGES.md`).
* Added `SttsBox::from_sample_deltas()` function to create an `SttsBox` instance from an iterator of sample deltas (`src/boxes.rs`).

### Module Additions:

* Introduced a new module `aux` in `src/lib.rs` to support additional functionalities.