### PR TITLE
AudioSampleEntryFields 構造体の整理（フィールドの型変更と定数追加）

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 ## develop
 
+- [ADD] `AudioSampleEntryFields::DEFAULT_DATA_REFERENCE_INDEX` 定数を追加する
+  - 通常の用途では `data_reference_index` には常にこの定数値が設定されることになる
+  - @sile
+- [CHANGE] `AudioSampleEntryFields.data_reference_index` の型を `u16` から `NonZeroU16` に変更する
+  - 値が 0 になることはないため non zero 版に変更した
+    - `VisualSampleEntryFields.data_reference_index` は元々 `NonZeroU16` だったので、両者の齟齬の解消も兼ねている
+  - @sile
 - [CHANGE] Rust のエディションを 2021 から 2024 に上げる
   - @sile
 - [FIX] ディスクリプターのサイズがリトルエンディアンでエンコードされていたのを修正する

--- a/src/boxes.rs
+++ b/src/boxes.rs
@@ -4000,13 +4000,16 @@ impl BaseBox for Mp4aBox {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub struct AudioSampleEntryFields {
-    pub data_reference_index: u16, // TODO: VisualSampleEntryFields に合わせて NonZeroU16 にする
+    pub data_reference_index: NonZeroU16,
     pub channelcount: u16,
     pub samplesize: u16,
     pub samplerate: FixedPointNumber<u16, u16>,
 }
 
 impl AudioSampleEntryFields {
+    /// [`AudioSampleEntryFields::data_reference_index`] のデフォルト値
+    pub const DEFAULT_DATA_REFERENCE_INDEX: NonZeroU16 = NonZeroU16::MIN;
+
     /// [`AudioSampleEntryFields::sample_size`] のデフォルト値 (16)
     pub const DEFAULT_SAMPLESIZE: u16 = 16;
 }
@@ -4028,7 +4031,7 @@ impl Encode for AudioSampleEntryFields {
 impl Decode for AudioSampleEntryFields {
     fn decode<R: Read>(mut reader: R) -> Result<Self> {
         let _ = <[u8; 6]>::decode(&mut reader)?;
-        let data_reference_index = u16::decode(&mut reader)?;
+        let data_reference_index = NonZeroU16::decode(&mut reader)?;
         let _ = <[u8; 4 * 2]>::decode(&mut reader)?;
         let channelcount = u16::decode(&mut reader)?;
         let samplesize = u16::decode(&mut reader)?;


### PR DESCRIPTION
Copilot Summary
-------------------

This pull request includes several changes to the `AudioSampleEntryFields` struct and related code in the `src/boxes.rs` file, as well as updates to the `CHANGES.md` file. The most important changes involve adding a new constant and modifying the type of a field to ensure consistency and prevent zero values.

### Changes to `AudioSampleEntryFields`:

* Added `DEFAULT_DATA_REFERENCE_INDEX` constant to `AudioSampleEntryFields` to provide a default value for `data_reference_index`. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R20) [[2]](diffhunk://#diff-7f32f2a87febc2bf043f4b5fd34f442a4d7476371edae2dcaa0502a5427330e1L4003-R4012)
* Changed the type of `data_reference_index` from `u16` to `NonZeroU16` to prevent zero values and align with `VisualSampleEntryFields`. [[1]](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R20) [[2]](diffhunk://#diff-7f32f2a87febc2bf043f4b5fd34f442a4d7476371edae2dcaa0502a5427330e1L4003-R4012) [[3]](diffhunk://#diff-7f32f2a87febc2bf043f4b5fd34f442a4d7476371edae2dcaa0502a5427330e1L4031-R4034)

### Documentation updates:

* Updated `CHANGES.md` to reflect the addition of `DEFAULT_DATA_REFERENCE_INDEX` and the type change of `data_reference_index`.