### PR TITLE
AAC 関連の定数を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
     - `EsDescriptor::LOWEST_STREAM_PRIORITY`
     - `DecoderConfigDescriptor::OBJECT_TYPE_INDICATION_AUDIO_ISO_IEC_14496_3`
     - `DecoderConfigDescriptor::STREAM_TYPE_AUDIO`
-    - `DecoderConfigDescriptor::DOWN_STREAM`
+    - `DecoderConfigDescriptor::UP_STREAM_FALSE`
   - @sile
 - [ADD] `AudioSampleEntryFields::DEFAULT_DATA_REFERENCE_INDEX` 定数を追加する
   - 通常の用途では `data_reference_index` には常にこの定数値が設定されることになる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,14 @@
 
 ## develop
 
+- [ADD] AAC 関連の定数を追加する
+  - MP4 に AAC ストリームを格納する際に、典型的に使用される値を以下の定数として定義した:
+    - `EsDescriptor::MIN_ES_ID`
+    - `EsDescriptor::LOWEST_STREAM_PRIORITY`
+    - `DecoderConfigDescriptor::OBJECT_TYPE_INDICATION_AUDIO_ISO_IEC_14496_3`
+    - `DecoderConfigDescriptor::STREAM_TYPE_AUDIO`
+    - `DecoderConfigDescriptor::DOWN_STREAM`
+  - @sile
 - [ADD] `AudioSampleEntryFields::DEFAULT_DATA_REFERENCE_INDEX` 定数を追加する
   - 通常の用途では `data_reference_index` には常にこの定数値が設定されることになる
   - @sile

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -18,6 +18,12 @@ pub struct EsDescriptor {
 
 impl EsDescriptor {
     const TAG: u8 = 3; // ES_DescrTag
+
+    /// [`EsDescriptor::es_id`] の実質的な最小値 (0 は予約されている）
+    pub const MIN_ES_ID: u16 = 1;
+
+    /// [`EsDescriptor::stream_priority`] で一番優先度が低くなる値
+    pub const LOWEST_STREAM_PRIORITY: Uint<u8, 5> = Uint::new(0);
 }
 
 impl Decode for EsDescriptor {
@@ -115,6 +121,15 @@ pub struct DecoderConfigDescriptor {
 
 impl DecoderConfigDescriptor {
     const TAG: u8 = 4; // DecoderConfigDescrTag
+
+    /// AAC 用の [`DecoderConfigDescriptor::object_type_indication`] の値
+    pub const OBJECT_TYPE_INDICATION_AUDIO_ISO_IEC_14496_3: u8 = 0x40;
+
+    /// 音声用の [`DecoderConfigDescriptor::stream_type`] の値
+    pub const STREAM_TYPE_AUDIO: Uint<u8, 6, 2> = Uint::new(0x05);
+
+    /// 通常の再生用メディアファイル向けの [`DecoderConfigDescriptor::up_stream`] の値
+    pub const DOWN_STREAM: Uint<u8, 1, 1> = Uint::new(0);
 }
 
 impl Decode for DecoderConfigDescriptor {

--- a/src/descriptors.rs
+++ b/src/descriptors.rs
@@ -129,7 +129,7 @@ impl DecoderConfigDescriptor {
     pub const STREAM_TYPE_AUDIO: Uint<u8, 6, 2> = Uint::new(0x05);
 
     /// 通常の再生用メディアファイル向けの [`DecoderConfigDescriptor::up_stream`] の値
-    pub const DOWN_STREAM: Uint<u8, 1, 1> = Uint::new(0);
+    pub const UP_STREAM_FALSE: Uint<u8, 1, 1> = Uint::new(0);
 }
 
 impl Decode for DecoderConfigDescriptor {


### PR DESCRIPTION
Copilot Summary
-------------------

This pull request includes the addition of several constants related to AAC (Advanced Audio Coding) in the `src/descriptors.rs` file. These constants are intended to be used when storing AAC streams in MP4 files. The changes also include updates to the `CHANGES.md` file to document these additions.

### Additions to AAC-related constants:

* `EsDescriptor` struct:
  * Added `MIN_ES_ID` constant to define the minimum value for `es_id`.
  * Added `LOWEST_STREAM_PRIORITY` constant to define the lowest stream priority value.

* `DecoderConfigDescriptor` struct:
  * Added `OBJECT_TYPE_INDICATION_AUDIO_ISO_IEC_14496_3` constant for the AAC object type indication.
  * Added `STREAM_TYPE_AUDIO` constant for the stream type value for audio.
  * Added `UP_STREAM_FALSE` constant for the up stream value for regular playback media files.

### Documentation updates:

* `CHANGES.md` file:
  * Documented the addition of the AAC-related constants.