### PR TITLE
MfraBox / Mp4FileDemuxer のデコード時の不具合を修正し fuzz ターゲットを追加する

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "shiguredo_mp4"
-version = "2026.2.0-canary.3"
+version = "2026.2.0-canary.5"
 
 [[package]]
 name = "shlex"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -467,6 +467,27 @@ doc = false
 bench = false
 
 [[bin]]
+name = "fuzz_mp4_file_demux"
+path = "fuzz_targets/fuzz_mp4_file_demux.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_mp4_file_kind_detector"
+path = "fuzz_targets/fuzz_mp4_file_kind_detector.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_fmp4_segment_mux"
+path = "fuzz_targets/fuzz_fmp4_segment_mux.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "fuzz_fmp4_file_demux"
 path = "fuzz_targets/fuzz_fmp4_file_demux.rs"
 test = false

--- a/fuzz/fuzz_targets/fuzz_fmp4_segment_mux.rs
+++ b/fuzz/fuzz_targets/fuzz_fmp4_segment_mux.rs
@@ -1,0 +1,65 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use shiguredo_mp4::demux::{Input, Mp4FileDemuxer};
+use shiguredo_mp4::mux::{Fmp4SegmentMuxer, Sample};
+
+fuzz_target!(|data: &[u8]| {
+    // 任意のバイト列を MP4 ファイルとしてデマルチプレクスし、
+    // 取得したサンプル情報を fMP4 セグメントとして再マルチプレクスしてもパニックしないことを確認する
+
+    // まず MP4 ファイルとしてデマルチプレクスを試みる
+    let mut demuxer = Mp4FileDemuxer::new();
+    let input = Input {
+        position: 0,
+        data,
+    };
+    demuxer.handle_input(input);
+
+    let tracks = match demuxer.tracks() {
+        Ok(tracks) => tracks.to_vec(),
+        Err(_) => return,
+    };
+
+    if tracks.is_empty() {
+        return;
+    }
+
+    // サンプルを収集する
+    let mut samples = Vec::new();
+    let mut data_offset = 0u64;
+    loop {
+        match demuxer.next_sample() {
+            Ok(Some(sample)) => {
+                let mux_sample = Sample {
+                    track_kind: sample.track.kind,
+                    timescale: sample.track.timescale,
+                    sample_entry: sample.sample_entry.cloned(),
+                    duration: sample.duration,
+                    keyframe: sample.keyframe,
+                    composition_time_offset: sample.composition_time_offset,
+                    data_offset,
+                    data_size: sample.data_size,
+                };
+                data_offset += sample.data_size as u64;
+                samples.push(mux_sample);
+            }
+            Ok(None) => break,
+            Err(_) => return,
+        }
+    }
+
+    if samples.is_empty() {
+        return;
+    }
+
+    // fMP4 セグメントとしてマルチプレクスする
+    let mut muxer = match Fmp4SegmentMuxer::new() {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    let _ = muxer.create_media_segment_metadata(&samples);
+    let _ = muxer.init_segment_bytes();
+    let _ = muxer.mfra_bytes();
+});

--- a/fuzz/fuzz_targets/fuzz_mp4_file_demux.rs
+++ b/fuzz/fuzz_targets/fuzz_mp4_file_demux.rs
@@ -1,0 +1,42 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use shiguredo_mp4::demux::{DemuxError, Input, Mp4FileDemuxer};
+
+fuzz_target!(|data: &[u8]| {
+    // 任意のバイト列を MP4 ファイルとして incremental に処理してもパニックしないことを確認する
+    let mut demuxer = Mp4FileDemuxer::new();
+
+    // 必要なデータを段階的に供給する
+    while let Some(required) = demuxer.required_input() {
+        let start = required.position as usize;
+        let Some(required_size) = required.size else {
+            // EOF まで必要な場合はファイル末尾までのデータを供給する
+            demuxer.handle_input(Input {
+                position: required.position,
+                data: data.get(start..).unwrap_or(&[]),
+            });
+            break;
+        };
+        let end = start.saturating_add(required_size).min(data.len());
+        demuxer.handle_input(Input {
+            position: required.position,
+            data: data.get(start..end).unwrap_or(&[]),
+        });
+    }
+
+    // トラック情報を取得する
+    if demuxer.tracks().is_err() {
+        return;
+    }
+
+    // 全サンプルを読み出す
+    loop {
+        match demuxer.next_sample() {
+            Ok(Some(_)) => continue,
+            Ok(None) => break,
+            Err(DemuxError::InputRequired(_)) => break,
+            Err(_) => break,
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_mp4_file_kind_detector.rs
+++ b/fuzz/fuzz_targets/fuzz_mp4_file_kind_detector.rs
@@ -1,0 +1,29 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use shiguredo_mp4::demux::{Input, Mp4FileKindDetector};
+
+fuzz_target!(|data: &[u8]| {
+    // 任意のバイト列に対してファイル種別判定を行ってもパニックしないことを確認する
+    let mut detector = Mp4FileKindDetector::new();
+
+    while let Some(required) = detector.required_input() {
+        let start = required.position as usize;
+        let end = match required.size {
+            Some(size) => start.saturating_add(size).min(data.len()),
+            None => data.len(),
+        };
+        detector.handle_input(Input {
+            position: required.position,
+            data: data.get(start..end).unwrap_or(&[]),
+        });
+
+        // 判定結果が出たら終了する
+        if let Ok(Some(_)) = detector.file_kind() {
+            break;
+        }
+    }
+
+    // 最終結果を取得する
+    let _ = detector.file_kind();
+});

--- a/src/boxes_fmp4.rs
+++ b/src/boxes_fmp4.rs
@@ -1032,9 +1032,8 @@ impl Decode for MfraBox {
                     }
                     _ => {
                         // 未知のボックスはスキップ
-                        offset += usize::try_from(child_header.box_size.get()).map_err(|_| {
-                            crate::Error::invalid_data("MfraBox child box size exceeds usize::MAX")
-                        })?;
+                        let (_, n) = UnknownBox::decode(&payload[offset..])?;
+                        offset += n;
                     }
                 }
             }

--- a/src/boxes_fmp4.rs
+++ b/src/boxes_fmp4.rs
@@ -1031,9 +1031,10 @@ impl Decode for MfraBox {
                         offset += n;
                     }
                     _ => {
-                        // 未知のボックスはスキップ
-                        let (_, n) = UnknownBox::decode(&payload[offset..])?;
-                        offset += n;
+                        // 未知のボックスはスキップ（ペイロードのコピーは不要なので BoxHeader のみでサイズを算出する）
+                        let (header, unknown_payload) =
+                            BoxHeader::decode_header_and_payload(&payload[offset..])?;
+                        offset += header.external_size() + unknown_payload.len();
                     }
                 }
             }

--- a/src/demux_mp4_file.rs
+++ b/src/demux_mp4_file.rs
@@ -212,6 +212,7 @@ impl<'a> Input<'a> {
         }
 
         if let Some(size) = size {
+            // 破損データで size が極端に大きい場合の加算オーバーフローを防ぐ
             let end = offset.checked_add(size)?;
             self.data.get(offset..end)
         } else {
@@ -483,6 +484,7 @@ impl Mp4FileDemuxer {
                     "moov box not found",
                 )));
             };
+            // 破損データで box_size が極端に大きい場合の加算オーバーフローを防ぐ
             let offset = offset.checked_add(box_size).ok_or_else(|| {
                 DemuxError::DecodeError(Error::invalid_data("box offset overflow"))
             })?;

--- a/src/demux_mp4_file.rs
+++ b/src/demux_mp4_file.rs
@@ -212,7 +212,8 @@ impl<'a> Input<'a> {
         }
 
         if let Some(size) = size {
-            self.data.get(offset..offset + size)
+            let end = offset.checked_add(size)?;
+            self.data.get(offset..end)
         } else {
             Some(&self.data[offset..])
         }
@@ -482,7 +483,9 @@ impl Mp4FileDemuxer {
                     "moov box not found",
                 )));
             };
-            let offset = offset + box_size;
+            let offset = offset.checked_add(box_size).ok_or_else(|| {
+                DemuxError::DecodeError(Error::invalid_data("box offset overflow"))
+            })?;
             self.phase = Phase::ReadMoovBoxHeader { offset };
         } else {
             let box_size = box_size.map(|n| n as usize);


### PR DESCRIPTION
## Summary

- MfraBox のデコードで未知ボックスの `box_size` が 0 の場合に `offset += 0` となり無限ループが発生する問題を修正する
- 未知ボックスのスキップ処理を `UnknownBox::decode()` を使う方式に変更し、MoofBox / TrafBox と同じパターンに統一する
- Mp4FileDemuxer の加算オーバーフローによるパニックを修正する

## 詳細

### MfraBox の無限ループ

ISO/IEC 14496-12 では `box_size` が 0 の場合「ファイル末尾まで」を意味する。`BoxHeader::decode_header_and_payload` はこのケースを正しく処理するが、MfraBox は直接 `box_size.get()` を使ってオフセットを加算していたため、サイズ 0 のボックスで無限ループが発生していた。

ファジング (`fuzz_mfra_box`) で検出されたタイムアウトが修正後は 0 ms で完了することを確認済み。

### Mp4FileDemuxer の加算オーバーフロー

新規追加した fuzz ターゲット (`fuzz_mp4_file_demux`, `fuzz_fmp4_segment_mux`) で以下の 2 つの加算オーバーフローによるパニックを検出・修正した:

1. `Input::slice_range()` の `offset + size` を `checked_add` に変更
2. `read_moov_box_header()` で moov 以外のボックスをスキップする際の `offset + box_size` を `checked_add` に変更

### fuzz ターゲットの追加

以下の 3 つの fuzz ターゲットを新規追加した:

- `fuzz_mp4_file_demux` — `Mp4FileDemuxer` の incremental demux
- `fuzz_mp4_file_kind_detector` — `Mp4FileKindDetector` のファイル種別判定
- `fuzz_fmp4_segment_mux` — MP4 demux → `Fmp4SegmentMuxer` ラウンドトリップ