### PR TITLE
dump_wasm から serde を外して nojson に寄せる

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,10 +69,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "dump_wasm"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
- "serde",
- "serde_json",
+ "nojson",
  "shiguredo_mp4",
 ]
 

--- a/examples/dump_wasm/Cargo.toml
+++ b/examples/dump_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump_wasm"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2024"
 publish = false
 
@@ -8,6 +8,5 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = "1.0.128"
+nojson = "0.3.10"
 shiguredo_mp4 = { "path" = "../../" }

--- a/examples/dump_wasm/src/lib.rs
+++ b/examples/dump_wasm/src/lib.rs
@@ -1,13 +1,9 @@
-use serde::Serialize;
 use shiguredo_mp4::{BaseBox, Decode, Mp4File, boxes::RootBox};
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 struct BoxInfo {
-    #[serde(rename = "type")]
     pub ty: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub unknown: Option<bool>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<Self>,
 }
 
@@ -21,18 +17,38 @@ impl BoxInfo {
     }
 }
 
+impl nojson::DisplayJson for BoxInfo {
+    fn fmt(&self, f: &mut nojson::JsonFormatter<'_, '_>) -> std::fmt::Result {
+        f.object(|f| {
+            f.member("type", &self.ty)?;
+            if let Some(unknown) = self.unknown {
+                f.member("unknown", unknown)?;
+            }
+            if !self.children.is_empty() {
+                f.member("children", &self.children)?;
+            }
+            Ok(())
+        })
+    }
+}
+
 #[unsafe(no_mangle)]
 #[expect(clippy::not_unsafe_ptr_arg_deref)]
 pub fn dump(bytes: *const u8, bytes_len: i32) -> *mut Vec<u8> {
     let bytes = unsafe { std::slice::from_raw_parts(bytes, bytes_len as usize) };
 
-    let json = Mp4File::<RootBox>::decode(bytes)
-        .map_err(|e| e.to_string())
-        .and_then(|(mp4, _)| {
+    let json = match Mp4File::<RootBox>::decode(bytes) {
+        Ok((mp4, _)) => {
             let infos = mp4.iter().map(BoxInfo::new).collect::<Vec<_>>();
-            serde_json::to_string_pretty(&infos).map_err(|e| e.to_string())
-        })
-        .unwrap_or_else(|e| e);
+            nojson::json(|f| {
+                f.set_indent_size(2);
+                f.set_spacing(true);
+                f.value(&infos)
+            })
+            .to_string()
+        }
+        Err(e) => e.to_string(),
+    };
 
     Box::into_raw(Box::new(json.into_bytes()))
 }


### PR DESCRIPTION
examples/dump_wasm の依存を整理する。

- serde / serde_json を nojson に置き換える
  - BoxInfo の Serialize derive を DisplayJson 手実装に置き換える
  - skip_serializing_if 相当の分岐は DisplayJson::fmt 内で条件分岐して表現する
  - serde_json::to_string_pretty はインデント 2 / spacing 有効の nojson::json で同等のフォーマットを再現する
- publish = false のクレートなのでバージョンを 0.0.0 にする