### PR TITLE
0001 mux_mp4_file.rs の data_size の u32 トランケーションを修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@
 
 ## develop
 
+- [FIX] `Mp4FileMuxer::append_sample()` で `sample.data_size` が `u32::MAX` を超える場合にエラーを返すようにする
+  - これまでは `usize` から `u32` への暗黙キャストで上位ビットが切り捨てられ、壊れた MP4 が生成される可能性があった
+  - `u32::try_from()` で明示的にチェックし、超過時は `MuxError::EncodeError` を返すように変更した
+  - 同様に `build_stbl_box` 内の `sample_per_chunk` でも `c.samples.len()` の `u32` 暗黙キャストを防御する
+  - @voluntas
+
 ## 2026.3.0
 
 - [ADD] `Mp4FileMuxer::advance_position()` メソッドを追加する

--- a/issues/closed/0001-bug-mux-mp4-file-data-size-truncation.md
+++ b/issues/closed/0001-bug-mux-mp4-file-data-size-truncation.md
@@ -1,7 +1,9 @@
 # mux_mp4_file.rs で sample.data_size の usize→u32 によるトランケーションが発生する
 
 Created: 2026-05-20
+Completed: 2026-05-20
 Model: opencode mimo-v2.5-pro
+Branch: feature/fix-mux-mp4-file-data-size-truncation
 
 ## 概要
 
@@ -94,3 +96,28 @@ fmp4 側と一貫性を取るため `EncodeError` を採用する)。
 
 C API (`crates/c-api/src/mux.rs`) の `Mp4MuxSample` でも `data_size` を受け取るが、
 C API 側では `u32` として扱っているため、今回の問題は発生しない。
+
+## 解決方法
+
+- `src/mux_mp4_file.rs:548` の `sample.data_size as u32` を
+  `u32::try_from(sample.data_size).map_err(|_| MuxError::EncodeError(Error::invalid_data("sample data size exceeds u32::MAX")))?`
+  に置き換え、`u32::MAX` を超えるサイズで明示的なエラーを返すようにした。
+  `mux_fmp4_segment.rs:744` 周辺と同じ防御パターンに揃えた。
+- レビューで `src/mux_mp4_file.rs:986` の `c.samples.len() as u32` も同型の暗黙
+  トランケーションを抱えていることが判明したため、同じく `u32::try_from()`
+  ベースに置き換え、`build_stbl_box` の `entries` 構築 closure を `Result<StscEntry, MuxError>`
+  返却にして `collect::<Result<_, _>>()?` で伝播するようにした。エラー文面は
+  `"samples per chunk exceeds u32::MAX"`。
+- `Mp4FileMuxer::append_sample()` の doc コメントに、エラー返却時の内部状態の
+  不変条件 (`MissingSampleEntry` 経路を除き `next_position` / `chunks` 等は
+  変更されない) を明記した。
+- `src/mux_mp4_file.rs` の `#[cfg(test)] mod tests` に以下 4 テストを追加した:
+  - `test_append_sample_data_size_u32_max_succeeds`: 境界値 `u32::MAX` で
+    `append_sample` と `finalize` が成功し、Co64Box 経路を通ることを検証する
+  - `test_append_sample_data_size_u32_max_with_faststart`: faststart 有効化
+    (`with_options`) 経路でも同じ境界値挙動を検証する
+  - `test_append_sample_data_size_exceeds_u32_max`: `u32::MAX + 1` で
+    `MuxError::EncodeError` が返り、その Display 出力が
+    `"sample data size exceeds u32::MAX"` を含むことを検証する (64-bit 限定)
+  - `test_append_sample_error_keeps_muxer_state`: エラー後に同じ `data_offset`
+    で正常サンプルを再投入できることを検証する (64-bit 限定)

--- a/src/mux_mp4_file.rs
+++ b/src/mux_mp4_file.rs
@@ -531,6 +531,11 @@ impl Mp4FileMuxer {
     /// 実際のデータ追記処理自体は利用側の責務であり、
     /// このメソッド目的は、その追記結果などを伝えることで、
     /// [`Mp4FileMuxer`] が適切に、MP4ファイルの再生に必要なメタデータを構築できるようにすることである。
+    ///
+    /// エラーを返した場合、内部状態 (`next_position` / `audio_chunks` / `video_chunks` /
+    /// `last_sample_kind`) は変更されないため、呼び出し側は内容を補正したサンプルで再呼び出しできる。
+    /// ただし、対象トラック種別の最初のサンプル投入直後に `MissingSampleEntry` エラーになった場合は、
+    /// そのトラックの `audio_track_timescale` または `video_track_timescale` だけは記録済みとなる。
     pub fn append_sample(&mut self, sample: &Sample) -> Result<(), MuxError> {
         if self.finalized_boxes.is_some() {
             return Err(MuxError::AlreadyFinalized);
@@ -545,7 +550,9 @@ impl Mp4FileMuxer {
         let metadata = SampleMetadata {
             duration: sample.duration,
             keyframe: sample.keyframe,
-            size: sample.data_size as u32,
+            size: u32::try_from(sample.data_size).map_err(|_| {
+                MuxError::EncodeError(Error::invalid_data("sample data size exceeds u32::MAX"))
+            })?,
             composition_time_offset: sample.composition_time_offset,
         };
 
@@ -973,19 +980,23 @@ impl Mp4FileMuxer {
             entries: chunks
                 .iter()
                 .enumerate()
-                .map(|(i, c)| {
+                .map(|(i, c)| -> Result<StscEntry, MuxError> {
                     let sample_description_index = sample_entries
                         .iter()
                         .position(|entry| entry == &c.sample_entry)
                         .map(|idx| NonZeroU32::MIN.saturating_add(idx as u32))
                         .expect("sample_entry should exist in sample_entries");
-                    StscEntry {
+                    Ok(StscEntry {
                         first_chunk: NonZeroU32::MIN.saturating_add(i as u32),
-                        sample_per_chunk: c.samples.len() as u32,
+                        sample_per_chunk: u32::try_from(c.samples.len()).map_err(|_| {
+                            MuxError::EncodeError(Error::invalid_data(
+                                "samples per chunk exceeds u32::MAX",
+                            ))
+                        })?,
                         sample_description_index,
-                    }
+                    })
                 })
-                .collect(),
+                .collect::<Result<Vec<_>, _>>()?,
         };
 
         let stsz_box = StszBox::Variable {
@@ -1123,6 +1134,8 @@ fn build_ctts_box(chunks: &[Chunk]) -> Result<Option<CttsBox>, MuxError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::format;
+
     use crate::{
         Uint,
         boxes::{
@@ -1273,6 +1286,130 @@ mod tests {
             muxer.append_sample(&sample2),
             Err(MuxError::AlreadyFinalized)
         ));
+    }
+
+    /// data_size が u32::MAX の境界値で append_sample と finalize が成功するテスト
+    ///
+    /// Mp4FileMuxer はメタデータのみを管理して実バイト列は確保しないため、
+    /// data_size に u32::MAX を渡しても 4 GiB の確保は発生しない。
+    /// next_position が u32::MAX を超えるため、finalize は Co64Box 経路を通る。
+    #[test]
+    fn test_append_sample_data_size_u32_max_succeeds() {
+        let mut muxer = Mp4FileMuxer::new().expect("failed to create muxer");
+        let initial_size = muxer.initial_boxes_bytes().len() as u64;
+
+        let sample = Sample {
+            track_kind: TrackKind::Video,
+            sample_entry: Some(create_avc1_sample_entry()),
+            keyframe: true,
+            timescale: NonZeroU32::MIN.saturating_add(30 - 1),
+            duration: 1,
+            composition_time_offset: None,
+            data_offset: initial_size,
+            data_size: u32::MAX as usize,
+        };
+        muxer
+            .append_sample(&sample)
+            .expect("failed to append sample with u32::MAX data_size");
+        let finalized = muxer.finalize().expect("failed to finalize muxer");
+        assert!(!finalized.moov_box_bytes.is_empty());
+    }
+
+    /// faststart 有効化 (with_options) 経路でも data_size の u32 境界が同様に防御されるテスト
+    #[test]
+    fn test_append_sample_data_size_u32_max_with_faststart() {
+        let options = Mp4FileMuxerOptions {
+            reserved_moov_box_size: 8192,
+            ..Default::default()
+        };
+        let mut muxer =
+            Mp4FileMuxer::with_options(options).expect("failed to create muxer with options");
+        let initial_size = muxer.initial_boxes_bytes().len() as u64;
+
+        let sample = Sample {
+            track_kind: TrackKind::Video,
+            sample_entry: Some(create_avc1_sample_entry()),
+            keyframe: true,
+            timescale: NonZeroU32::MIN.saturating_add(30 - 1),
+            duration: 1,
+            composition_time_offset: None,
+            data_offset: initial_size,
+            data_size: u32::MAX as usize,
+        };
+        muxer
+            .append_sample(&sample)
+            .expect("failed to append sample with u32::MAX data_size under faststart");
+        let finalized = muxer.finalize().expect("failed to finalize muxer");
+        assert!(finalized.is_faststart_enabled());
+    }
+
+    /// data_size が u32::MAX を超える場合のエラーテスト
+    // 32-bit プラットフォームでは usize で u32::MAX + 1 を表現できず構造的に到達不能なため cfg で限定する
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_append_sample_data_size_exceeds_u32_max() {
+        let mut muxer = Mp4FileMuxer::new().expect("failed to create muxer");
+        let initial_size = muxer.initial_boxes_bytes().len() as u64;
+
+        let sample = Sample {
+            track_kind: TrackKind::Video,
+            sample_entry: Some(create_avc1_sample_entry()),
+            keyframe: true,
+            timescale: NonZeroU32::MIN.saturating_add(30 - 1),
+            duration: 1,
+            composition_time_offset: None,
+            data_offset: initial_size,
+            data_size: u32::MAX as usize + 1,
+        };
+        let err = muxer
+            .append_sample(&sample)
+            .expect_err("expected encode error for data_size exceeding u32::MAX");
+        assert!(matches!(err, MuxError::EncodeError(_)));
+        // MuxError::EncodeError は他原因でも返るためメッセージ内容まで確認する
+        let message = format!("{err}");
+        assert!(
+            message.contains("sample data size exceeds u32::MAX"),
+            "unexpected error message: {message}",
+        );
+    }
+
+    /// append_sample がエラーを返した後にミューサ状態が変化していないことを検証するテスト
+    // 32-bit プラットフォームでは usize で u32::MAX + 1 を表現できず構造的に到達不能なため cfg で限定する
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_append_sample_error_keeps_muxer_state() {
+        let mut muxer = Mp4FileMuxer::new().expect("failed to create muxer");
+        let initial_size = muxer.initial_boxes_bytes().len() as u64;
+
+        let bad_sample = Sample {
+            track_kind: TrackKind::Video,
+            sample_entry: Some(create_avc1_sample_entry()),
+            keyframe: true,
+            timescale: NonZeroU32::MIN.saturating_add(30 - 1),
+            duration: 1,
+            composition_time_offset: None,
+            data_offset: initial_size,
+            data_size: u32::MAX as usize + 1,
+        };
+        muxer
+            .append_sample(&bad_sample)
+            .expect_err("expected encode error for data_size exceeding u32::MAX");
+
+        // エラー後でも next_position は初期値のままなので、同じ data_offset で再投入できる
+        let good_sample = Sample {
+            track_kind: TrackKind::Video,
+            sample_entry: Some(create_avc1_sample_entry()),
+            keyframe: true,
+            timescale: NonZeroU32::MIN.saturating_add(30 - 1),
+            duration: 1,
+            composition_time_offset: None,
+            data_offset: initial_size,
+            data_size: 1024,
+        };
+        muxer
+            .append_sample(&good_sample)
+            .expect("failed to append sample after error");
+        muxer.finalize().expect("failed to finalize muxer");
     }
 
     /// 音声と映像の複数トラックのテスト


### PR DESCRIPTION
## 概要

`src/mux_mp4_file.rs:548` の `sample.data_size as u32` の暗黙トランケーションを修正し、`u32::MAX` を超える `data_size` を渡された場合に `MuxError::EncodeError` を返すようにする。

## 変更内容

- `src/mux_mp4_file.rs:548`: `sample.data_size as u32` を `u32::try_from()` に置き換え、`MuxError::EncodeError(Error::invalid_data("sample data size exceeds u32::MAX"))` を返すようにする
- `src/mux_mp4_file.rs:986`: `c.samples.len() as u32` も同型の暗黙トランケーションを抱えていたため、同じく `u32::try_from()` で防御 (エラー文面 "samples per chunk exceeds u32::MAX")
- `Mp4FileMuxer::append_sample()` の doc コメントに、エラー返却時の内部状態の不変条件 (`MissingSampleEntry` 経路を除き `next_position` / `chunks` / `last_sample_kind` は変更されない) を明記する
- `src/mux_mp4_file.rs` の `#[cfg(test)] mod tests` に以下 4 テストを追加する:
  - `test_append_sample_data_size_u32_max_succeeds`: 境界値 `u32::MAX` で `append_sample` と `finalize` が成功し、Co64Box 経路を通ることを検証
  - `test_append_sample_data_size_u32_max_with_faststart`: faststart 有効化 (`with_options`) 経路でも同じ境界値挙動を検証
  - `test_append_sample_data_size_exceeds_u32_max`: `u32::MAX + 1` で `MuxError::EncodeError` が返り、Display 出力が `"sample data size exceeds u32::MAX"` を含むことを検証 (64-bit 限定)
  - `test_append_sample_error_keeps_muxer_state`: エラー後に同じ `data_offset` で正常サンプルを再投入できることを検証 (64-bit 限定)
- `CHANGES.md` の `## develop` セクションに `[FIX]` エントリを追加する

## 設計判断

`MuxError` の種別は `MuxError::Overflow` という候補もあるが、`mux_fmp4_segment.rs:744` 周辺で既に同型の防御に `MuxError::EncodeError(Error::invalid_data(...))` を採用しているため、一貫性を取って `EncodeError` を選択する。

## 完了条件

- [x] `data_size > u32::MAX` で `Mp4FileMuxer::append_sample()` がエラーを返す
- [x] エラー型は `MuxError::EncodeError`、メッセージは `"sample data size exceeds u32::MAX"`
- [x] `u32::MAX` の境界値では成功し、`finalize()` まで通る
- [x] 32-bit プラットフォームでも構造的に到達不能なエラーパスとしてビルド・テストが通る
- [x] `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` / `cargo doc -D warnings` が通る

## 関連 issue

- issues/closed/0001-bug-mux-mp4-file-data-size-truncation.md