### PR TITLE
0002 mux_mp4_file.rs の映像解像度 i16 符号反転を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
   - `u32::try_from()` で明示的にチェックし、超過時は `MuxError::EncodeError` を返すように変更した
   - 同様に `build_stbl_box` 内の `sample_per_chunk` でも `c.samples.len()` の `u32` 暗黙キャストを防御する
   - @voluntas
+- [FIX] `Mp4FileMuxer` の `build_video_trak_box()` で映像解像度の幅と高さが `i16::MAX` を超える場合にエラーを返すようにする
+  - これまでは `u16` から `i16` への暗黙キャストで符号が反転し、`tkhd` の `width` / `height` が負の値になる可能性があった
+  - `i16::try_from()` で明示的にチェックし、超過時は `MuxError::EncodeError` を返すように変更した
+  - @voluntas
 
 ## 2026.3.0
 

--- a/issues/closed/0002-bug-mux-mp4-file-resolution-sign-inversion.md
+++ b/issues/closed/0002-bug-mux-mp4-file-resolution-sign-inversion.md
@@ -1,7 +1,9 @@
 # mux_mp4_file.rs で映像解像度の u16→i16 キャストにより符号反転が発生する
 
 Created: 2026-05-20
+Completed: 2026-05-20
 Model: opencode mimo-v2.5-pro
+Branch: feature/fix-mux-mp4-file-resolution-sign-inversion
 
 ## 概要
 
@@ -108,3 +110,21 @@ height: FixedPointNumber::new(i16::try_from(max_height).map_err(|_| {
 ## CHANGES.md
 
 `[FIX]` で記載する。
+
+## 解決方法
+
+- `src/mux_mp4_file.rs` の `build_video_trak_box` で `max_width as i16` / `max_height as i16` の
+  暗黙キャストを `i16::try_from()` ベースに置き換えた。エラー時は
+  `MuxError::EncodeError(Error::invalid_data("video {width|height} exceeds i16::MAX"))` を返す。
+  `mux_fmp4_segment.rs:613-636` と同じ防御パターンに揃えている。
+- `src/mux_mp4_file.rs` の `#[cfg(test)] mod tests` に共通ヘルパー
+  `finalize_after_appending_video_sample(muxer, width, height)` を追加し、
+  以下 4 テストを実装した:
+  - `test_finalize_video_resolution_i16_max_succeeds`: width/height が `i16::MAX` (32767)
+    の境界値で `finalize()` が成功することを検証する
+  - `test_finalize_video_resolution_i16_max_with_faststart`: faststart 有効化
+    (`Mp4FileMuxerOptions::reserved_moov_box_size > 0`) 経路でも同じ境界値挙動を検証する
+  - `test_finalize_video_width_exceeds_i16_max`: width = 32768 で `MuxError::EncodeError`
+    が返り、Display 出力が `"video width exceeds i16::MAX"` を含むことを検証する
+  - `test_finalize_video_height_exceeds_i16_max`: height = 32768 で同様に
+    `"video height exceeds i16::MAX"` を含むことを検証する

--- a/src/mux_mp4_file.rs
+++ b/src/mux_mp4_file.rs
@@ -855,6 +855,13 @@ impl Mp4FileMuxer {
                 (max_w.max(w), max_h.max(h))
             });
 
+        let width = i16::try_from(max_width).map_err(|_| {
+            MuxError::EncodeError(Error::invalid_data("video width exceeds i16::MAX"))
+        })?;
+        let height = i16::try_from(max_height).map_err(|_| {
+            MuxError::EncodeError(Error::invalid_data("video height exceeds i16::MAX"))
+        })?;
+
         let creation_time = Mp4FileTime::from_unix_time(self.options.creation_timestamp);
         let tkhd_box = TkhdBox {
             flag_track_enabled: true,
@@ -869,8 +876,8 @@ impl Mp4FileMuxer {
             alternate_group: TkhdBox::DEFAULT_ALTERNATE_GROUP,
             volume: TkhdBox::DEFAULT_VIDEO_VOLUME,
             matrix: TkhdBox::DEFAULT_MATRIX,
-            width: FixedPointNumber::new(max_width as i16, 0),
-            height: FixedPointNumber::new(max_height as i16, 0),
+            width: FixedPointNumber::new(width, 0),
+            height: FixedPointNumber::new(height, 0),
         };
 
         Ok(TrakBox {
@@ -1410,6 +1417,89 @@ mod tests {
             .append_sample(&good_sample)
             .expect("failed to append sample after error");
         muxer.finalize().expect("failed to finalize muxer");
+    }
+
+    /// `muxer` に解像度 `width` x `height` の AVC1 サンプルを 1 つ追加して `finalize()` を呼ぶ
+    fn finalize_after_appending_video_sample(
+        muxer: &mut Mp4FileMuxer,
+        width: u16,
+        height: u16,
+    ) -> Result<(), MuxError> {
+        let initial_size = muxer.initial_boxes_bytes().len() as u64;
+        let mut entry = create_avc1_sample_entry();
+        let SampleEntry::Avc1(avc1) = &mut entry else {
+            panic!("create_avc1_sample_entry must return SampleEntry::Avc1");
+        };
+        avc1.visual.width = width;
+        avc1.visual.height = height;
+
+        let sample = Sample {
+            track_kind: TrackKind::Video,
+            sample_entry: Some(entry),
+            keyframe: true,
+            timescale: NonZeroU32::MIN.saturating_add(30 - 1),
+            duration: 1,
+            composition_time_offset: None,
+            data_offset: initial_size,
+            data_size: 1024,
+        };
+        muxer
+            .append_sample(&sample)
+            .expect("failed to append sample");
+        muxer.finalize().map(|_| ())
+    }
+
+    /// 映像解像度の幅と高さが i16::MAX (32767) の境界値で finalize が成功するテスト
+    #[test]
+    fn test_finalize_video_resolution_i16_max_succeeds() {
+        let mut muxer = Mp4FileMuxer::new().expect("failed to create muxer");
+        finalize_after_appending_video_sample(&mut muxer, i16::MAX as u16, i16::MAX as u16)
+            .expect("failed to finalize at i16::MAX resolution");
+    }
+
+    /// faststart 有効化 (with_options) 経路でも i16::MAX 境界値で finalize が成功するテスト
+    #[test]
+    fn test_finalize_video_resolution_i16_max_with_faststart() {
+        let options = Mp4FileMuxerOptions {
+            reserved_moov_box_size: 8192,
+            ..Default::default()
+        };
+        let mut muxer =
+            Mp4FileMuxer::with_options(options).expect("failed to create muxer with options");
+        finalize_after_appending_video_sample(&mut muxer, i16::MAX as u16, i16::MAX as u16)
+            .expect("failed to finalize at i16::MAX resolution under faststart");
+    }
+
+    /// 映像幅が i16::MAX を超える場合に width 側のエラーメッセージが返ることを検証するテスト
+    #[test]
+    fn test_finalize_video_width_exceeds_i16_max() {
+        // i16::MAX を超える最小値の u16 (= 32768) を渡す
+        let mut muxer = Mp4FileMuxer::new().expect("failed to create muxer");
+        let err = finalize_after_appending_video_sample(&mut muxer, 32_768, 1)
+            .expect_err("expected encode error for width exceeding i16::MAX");
+        assert!(matches!(err, MuxError::EncodeError(_)));
+        // MuxError::EncodeError は他原因でも返るためメッセージ内容まで確認する
+        let message = format!("{err}");
+        assert!(
+            message.contains("video width exceeds i16::MAX"),
+            "unexpected error message: {message}",
+        );
+    }
+
+    /// 映像高さが i16::MAX を超える場合に height 側のエラーメッセージが返ることを検証するテスト
+    #[test]
+    fn test_finalize_video_height_exceeds_i16_max() {
+        // i16::MAX を超える最小値の u16 (= 32768) を渡す
+        let mut muxer = Mp4FileMuxer::new().expect("failed to create muxer");
+        let err = finalize_after_appending_video_sample(&mut muxer, 1, 32_768)
+            .expect_err("expected encode error for height exceeding i16::MAX");
+        assert!(matches!(err, MuxError::EncodeError(_)));
+        // MuxError::EncodeError は他原因でも返るためメッセージ内容まで確認する
+        let message = format!("{err}");
+        assert!(
+            message.contains("video height exceeds i16::MAX"),
+            "unexpected error message: {message}",
+        );
     }
 
     /// 音声と映像の複数トラックのテスト


### PR DESCRIPTION
## 概要

`src/mux_mp4_file.rs` の `build_video_trak_box` で `max_width as i16` / `max_height as i16` の暗黙キャストにより、`32768` 以上の解像度が指定された場合に符号が反転して負の `tkhd.width` / `tkhd.height` が書き出されるバグを修正する。

## 変更内容

- `src/mux_mp4_file.rs`: `max_width as i16` / `max_height as i16` を `i16::try_from()` に置き換え、エラー時は `MuxError::EncodeError(Error::invalid_data("video {width|height} exceeds i16::MAX"))` を返す。`mux_fmp4_segment.rs:613-636` と同じ防御パターン
- `src/mux_mp4_file.rs` の `#[cfg(test)] mod tests`:
  - 共通ヘルパー `finalize_after_appending_video_sample(muxer, width, height)` を追加。`let-else` でサンプルエントリ取り出しの silent skip リスクを排除
  - テスト 4 件を追加:
    - `test_finalize_video_resolution_i16_max_succeeds`: `i16::MAX` (32767) の境界値で `finalize()` が成功
    - `test_finalize_video_resolution_i16_max_with_faststart`: faststart 経路でも同様
    - `test_finalize_video_width_exceeds_i16_max`: `width = 32768` で `MuxError::EncodeError` + メッセージ `"video width exceeds i16::MAX"`
    - `test_finalize_video_height_exceeds_i16_max`: `height = 32768` で同様に `"video height exceeds i16::MAX"`
- `CHANGES.md`: `## develop` セクションに `[FIX]` エントリを追加

## 設計判断

`MuxError::Overflow` という候補もあるが、`mux_fmp4_segment.rs:613-636` の既存防御と一貫させるため `MuxError::EncodeError(Error::invalid_data(...))` を採用する。

## 完了条件

- [x] `width` または `height` が `i16::MAX` を超える場合に `finalize()` が `MuxError::EncodeError` を返す
- [x] エラーメッセージは `"video width exceeds i16::MAX"` / `"video height exceeds i16::MAX"`
- [x] `i16::MAX` の境界値では成功する
- [x] faststart 経路でも同じ挙動になる
- [x] `cargo fmt --check` / `cargo clippy -D warnings` / `cargo test` / `cargo doc -D warnings` が通る

## スコープ外（別 issue 候補として整理）

レビューで以下が指摘されたが、本 PR のスコープを超えるため別 issue 化を推奨する:

- `TkhdBox.width` / `height` の型を `FixedPointNumber<i16, u16>` から `<u16, u16>` に変更する（ISO/IEC 14496-12 §8.3.2.2 の仕様一次資料確認が必要）
- エラーメッセージにトラック ID や実際の値を含めて識別性を高める（`mux_fmp4_segment.rs` と同時変更が必要）
- `pbt/tests/prop_mux_demux.rs` の `width` / `height` strategy を `i16::MAX` 近傍まで拡張する

## 関連 issue

- issues/closed/0002-bug-mux-mp4-file-resolution-sign-inversion.md