### PR TITLE
0005 Mp4FileMuxer の fuzz ターゲットを追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,12 @@
   - `i16::try_from()` で明示的にチェックし、超過時は `MuxError::EncodeError` を返すように変更した
   - @voluntas
 
+### misc
+
+- [ADD] `Mp4FileMuxer` の fuzz ターゲット (`fuzz_mp4_file_mux`) を追加する
+  - demux → mux パターンで任意バイト列に対するパニック安全性を検証する
+  - @voluntas
+
 ## 2026.3.0
 
 - [ADD] `Mp4FileMuxer::advance_position()` メソッドを追加する

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -86,7 +86,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "shiguredo_mp4"
-version = "2026.2.0"
+version = "2026.3.0"
 
 [[package]]
 name = "shlex"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -493,3 +493,10 @@ path = "fuzz_targets/fuzz_fmp4_file_demux.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_mp4_file_mux"
+path = "fuzz_targets/fuzz_mp4_file_mux.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_mp4_file_mux.rs
+++ b/fuzz/fuzz_targets/fuzz_mp4_file_mux.rs
@@ -1,0 +1,103 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use shiguredo_mp4::demux::{Input, Mp4FileDemuxer};
+use shiguredo_mp4::mux::{Mp4FileMuxer, Mp4FileMuxerOptions, Sample};
+
+fuzz_target!(|data: &[u8]| {
+    // 任意のバイト列を MP4 ファイルとしてデマルチプレクスし、
+    // 取得したサンプル情報を Mp4FileMuxer で再マルチプレクスしてもパニックしないことを確認する
+
+    if data.is_empty() {
+        return;
+    }
+
+    // 先頭 1 バイトの最上位ビットで faststart 経路の分岐を決定する
+    let use_faststart = data[0] & 0x80 != 0;
+
+    // MP4 ファイルとしてデマルチプレクスを試みる
+    let mut demuxer = Mp4FileDemuxer::new();
+    let input = Input {
+        position: 0,
+        data,
+    };
+    demuxer.handle_input(input);
+
+    let tracks = match demuxer.tracks() {
+        Ok(tracks) => tracks.to_vec(),
+        Err(_) => return,
+    };
+
+    if tracks.is_empty() {
+        return;
+    }
+
+    // サンプルを収集する
+    let mut samples = Vec::new();
+    let mut data_offset = 0u64;
+    loop {
+        match demuxer.next_sample() {
+            Ok(Some(sample)) => {
+                let mux_sample = Sample {
+                    track_kind: sample.track.kind,
+                    timescale: sample.track.timescale,
+                    sample_entry: sample.sample_entry.cloned(),
+                    duration: sample.duration,
+                    keyframe: sample.keyframe,
+                    composition_time_offset: sample.composition_time_offset,
+                    data_offset,
+                    data_size: sample.data_size,
+                };
+                data_offset += sample.data_size as u64;
+                samples.push(mux_sample);
+            }
+            Ok(None) => break,
+            Err(_) => return,
+        }
+    }
+
+    if samples.is_empty() {
+        return;
+    }
+
+    // Mp4FileMuxer を生成する
+    let mut muxer = if use_faststart {
+        let options = Mp4FileMuxerOptions {
+            reserved_moov_box_size: 8192,
+            ..Default::default()
+        };
+        match Mp4FileMuxer::with_options(options) {
+            Ok(m) => m,
+            Err(_) => return,
+        }
+    } else {
+        match Mp4FileMuxer::new() {
+            Ok(m) => m,
+            Err(_) => return,
+        }
+    };
+
+    // data_offset を initial_boxes_bytes の長さを基準に再計算して mux に投入する
+    let base_offset = muxer.initial_boxes_bytes().len() as u64;
+    for sample in &mut samples {
+        sample.data_offset += base_offset;
+    }
+
+    for sample in &samples {
+        if muxer.append_sample(sample).is_err() {
+            return;
+        }
+    }
+
+    // finalize してもパニックしないことを確認する
+    let finalized = match muxer.finalize() {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+
+    // FinalizedBoxes のメソッドを呼び出してパニックしないことを確認する
+    let _ = finalized.is_faststart_enabled();
+    let _ = finalized.moov_box_size();
+    let _ = finalized.moov_box();
+    for _ in finalized.offset_and_bytes_pairs() {}
+});

--- a/issues/closed/0005-add-fuzz-mp4-file-muxer.md
+++ b/issues/closed/0005-add-fuzz-mp4-file-muxer.md
@@ -2,6 +2,7 @@
 
 - Priority: Medium
 - Created: 2026-05-26
+- Completed: 2026-05-26
 - Model: Opus 4.7
 - Branch: feature/add-fuzz-mp4-file-muxer
 
@@ -101,3 +102,14 @@ fuzz ターゲットの追加は機能に直接影響しない変更のため、
 - `fuzz/fuzz_targets/fuzz_mp4_file_mux.rs` が追加されている
 - `fuzz/Cargo.toml` に `[[bin]]` エントリが追加されている
 - `cargo fuzz build fuzz_mp4_file_mux` が成功する
+
+## 解決方法
+
+- `fuzz/fuzz_targets/fuzz_mp4_file_mux.rs` を新規作成した
+  - `fuzz_fmp4_segment_mux.rs` の demux → mux パターンをベースに、`Mp4FileMuxer` 固有の制約に対応
+  - demux ループ内で直接 `mux::Sample` を構築し `Vec<Sample>` に収集する
+  - `data_offset` は 0 起点で積み上げ、muxer 生成後に `initial_boxes_bytes().len()` を一括加算する
+  - 先頭 1 バイトの最上位ビットで `new()` / `with_options(reserved_moov_box_size: 8192)` を切り替え、faststart 経路をカバーする
+  - `finalize()` 後に `FinalizedBoxes` の全メソッドを呼び出してパニック安全性を確認する
+- `fuzz/Cargo.toml` に `[[bin]]` エントリを追加した
+- 30 秒間の fuzzing 実行（8,220,271 回）でクラッシュなしを確認した


### PR DESCRIPTION
## 概要

Mp4FileMuxer に対応する fuzz ターゲットが存在しないため、demux → mux パターンで任意バイト列に対するパニック安全性を検証する fuzz ターゲットを追加する。

## 変更内容

- `fuzz/fuzz_targets/fuzz_mp4_file_mux.rs` を新規作成
  - 任意バイト列を Mp4FileDemuxer でデマルチプレクスし、取得したサンプルを Mp4FileMuxer で再マルチプレクスしてもパニックしないことを確認する
  - 先頭 1 バイトの最上位ビットで `new()` / `with_options(reserved_moov_box_size: 8192)` を切り替え、faststart 経路をカバーする
  - `finalize()` 後に `FinalizedBoxes` の全メソッドを呼び出してパニック安全性を確認する
- `fuzz/Cargo.toml` に `[[bin]]` エントリを追加
- `CHANGES.md` の `### misc` に追記

## 完了条件

- [x] `fuzz/fuzz_targets/fuzz_mp4_file_mux.rs` が追加されている
- [x] `fuzz/Cargo.toml` に `[[bin]]` エントリが追加されている
- [x] `cargo fuzz build fuzz_mp4_file_mux` が成功する

## 関連 issue

- issues/closed/0005-add-fuzz-mp4-file-muxer.md