### PR TITLE
0007 fuzz_basic_types に SampleFlags の decode/encode を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@
 - [ADD] `SampleTableAccessor` の fuzz ターゲット (`fuzz_sample_table_accessor`) を追加する
   - `StblBox::decode()` から直接構築し、全アクセサメソッドのパニック安全性を検証する
   - @voluntas
+- [UPDATE] `fuzz_basic_types` に `SampleFlags` の decode/encode を追加する
+  - @voluntas
 
 ## 2026.3.0
 

--- a/fuzz/fuzz_targets/fuzz_basic_types.rs
+++ b/fuzz/fuzz_targets/fuzz_basic_types.rs
@@ -2,7 +2,8 @@
 
 use libfuzzer_sys::fuzz_target;
 use shiguredo_mp4::{
-    Decode, Encode, FixedPointNumber, FullBoxFlags, FullBoxHeader, Utf8String, boxes::Brand,
+    Decode, Encode, FixedPointNumber, FullBoxFlags, FullBoxHeader, SampleFlags, Utf8String,
+    boxes::Brand,
 };
 
 fuzz_target!(|data: &[u8]| {
@@ -20,5 +21,8 @@ fuzz_target!(|data: &[u8]| {
     }
     if let Ok((brand, _)) = Brand::decode(data) {
         let _ = brand.encode_to_vec();
+    }
+    if let Ok((flags, _)) = SampleFlags::decode(data) {
+        let _ = flags.encode_to_vec();
     }
 });

--- a/issues/closed/0007-add-fuzz-basic-types-sample-flags.md
+++ b/issues/closed/0007-add-fuzz-basic-types-sample-flags.md
@@ -2,6 +2,7 @@
 
 - Priority: Low
 - Created: 2026-05-26
+- Completed: 2026-05-26
 - Model: Opus 4.7
 - Branch: feature/add-fuzz-basic-types-sample-flags
 
@@ -47,3 +48,9 @@ fuzz ターゲットの変更は機能に直接影響しない変更のため、
 
 - `fuzz/fuzz_targets/fuzz_basic_types.rs` に `SampleFlags` のデコード・エンコードが追加されている
 - `cargo fuzz build fuzz_basic_types` が成功する
+
+## 解決方法
+
+- `fuzz/fuzz_targets/fuzz_basic_types.rs` に `SampleFlags` の decode/encode を既存パターンに従って追加した
+- import に `SampleFlags` を追加し、`Brand` の decode/encode の後に同じパターンで追記した
+- 30 秒間の fuzzing 実行（4,844,853 回）でクラッシュなしを確認した


### PR DESCRIPTION
## 概要

fuzz_basic_types.rs は basic_types.rs 内の Decode 実装型を対象とする fuzz ターゲットだが、SampleFlags だけが漏れているため追加する。

## 変更内容

- `fuzz/fuzz_targets/fuzz_basic_types.rs` に `SampleFlags` の decode/encode を既存パターンに従って追加
- `CHANGES.md` の `### misc` に追記

## 完了条件

- [x] `fuzz/fuzz_targets/fuzz_basic_types.rs` に `SampleFlags` のデコード・エンコードが追加されている
- [x] `cargo fuzz build fuzz_basic_types` が成功する

## 関連 issue

- issues/closed/0007-add-fuzz-basic-types-sample-flags.md